### PR TITLE
Use data: { confirm: 'Text' } to fix confirm: 'Text' deprecation

### DIFF
--- a/app/views/letter_opener_web/letters/index.html.erb
+++ b/app/views/letter_opener_web/letters/index.html.erb
@@ -6,7 +6,7 @@
         <i class="icon-refresh"></i>
         Refresh
       <% end %>
-      <%= link_to clear_letters_path, method: 'delete', confirm: 'Are you sure?', class: 'btn btn-danger' do %>
+      <%= link_to clear_letters_path, method: 'delete', data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' do %>
         <i class="icon-trash icon-white"></i>
         Clear
       <% end %>


### PR DESCRIPTION
Fixes this deprecation warning:

```
DEPRECATION WARNING: :confirm option is deprecated and will be removed from Rails 4.1. Use 'data: { confirm: 'Text' }' instead. (called from realtime at /Users/rpai/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/benchmark.rb:296)
```
