### PR TITLE
Deal with empty href tags

### DIFF
--- a/app/models/letter_opener_web/letter.rb
+++ b/app/models/letter_opener_web/letter.rb
@@ -74,6 +74,7 @@ module LetterOpenerWeb
         xml        = REXML::Document.new(fixed_link).root
         unless xml.attributes['href'] =~ /(plain|rich).html/
           xml.attributes['target'] = '_blank'
+          xml.add_text('') unless xml.text
           contents.gsub!(link, xml.to_s)
         end
       end

--- a/spec/models/letter_opener_web/letter_spec.rb
+++ b/spec/models/letter_opener_web/letter_spec.rb
@@ -12,6 +12,7 @@ Rich text for #{mail_id}
   Link text
 </a>
 <a href='fooo.html'>Bar</a>
+<a href="example.html" class="blank"></a>
 MAIL
   end
 
@@ -41,6 +42,11 @@ MAIL
     it 'changes links to show up on a new window' do
       return pending 'This spec if failing randomly on ruby 1.8' if RUBY_VERSION =~ /^1.8/
       subject.should include("<a href='a-link.html' target='_blank'>\n  <img src='an-image.jpg'/>\n  Link text\n</a>")
+    end
+
+    it 'always rewrites links with a closing tag rather than making them selfclosing' do
+      return pending 'This spec if failing randomly on ruby 1.8' if RUBY_VERSION =~ /^1.8/
+      subject.should include("<a class='blank' href='example.html' target='_blank'></a>")
     end
   end
 


### PR DESCRIPTION
The `adjust_link_targets` method uses an XML parser to find and rewrite `<a>` tags to include the `target='_blank'`. If there is a link on the page that contains no content between the open and close tags the XML parser will convert it to a self closing tag. Most web browsers will auto-correct a self closing link tag to be just an opening tag and the remainder of the email will be highlighted as a link.

This:

``` html
<a href="example.com"></a>
```

Becomes this:

``` html
<a href='example.com' target='_blank'/>
```

And is parsed as this:

``` html
<a href='example.com' target='_blank'>
```

And that breaks the rest of the document.

The solution is to insert an empty string as text if the content of the node is `nil`.
