### PR TITLE
change link regex to look for space. Avoids matching <address> tag

### DIFF
--- a/app/models/letter_opener_web/letter.rb
+++ b/app/models/letter_opener_web/letter.rb
@@ -69,7 +69,7 @@ module LetterOpenerWeb
       # "complete" (as in they have the whole <html> structure) and letter_opener
       # prepends some information about the mail being sent, making REXML
       # complain about it
-      contents.scan(/<a[^>]+>(?:.|\s)*?<\/a>/).each do |link|
+      contents.scan(/<a\s[^>]+>(?:.|\s)*?<\/a>/).each do |link|
         fixed_link = fix_link_html(link)
         xml        = REXML::Document.new(fixed_link).root
         unless xml.attributes['href'] =~ /(plain|rich).html/


### PR DESCRIPTION
I ran into issues when my emails had `<address>`tags in the HTML. The regex was matching the `<a` all the way to the end of my next close `</a>` tag.

I added a space to only match `<a href=....` tags.
