### PR TITLE
Remove redundant asset_path() call

### DIFF
--- a/app/views/layouts/letter_opener_web/application.html.erb
+++ b/app/views/layouts/letter_opener_web/application.html.erb
@@ -4,7 +4,7 @@
   <title>LetterOpenerWeb</title>
   <%= stylesheet_link_tag    "letter_opener_web/application", :media => "all" %>
   <%= javascript_include_tag "letter_opener_web/application" %>
-  <%= favicon_link_tag       asset_path("letter_opener_web/blue-dot.ico"), :rel => "icon" %>
+  <%= favicon_link_tag       "letter_opener_web/blue-dot.ico", :rel => "icon" %>
   <%= csrf_meta_tags %>
 </head>
 <body>


### PR DESCRIPTION
`favicon_link_tag()` calls `asset_path()` without the need of explicitly call it.

This also fixes issue #32 (exception with sprockets-rails >= 2.1.4).
