### PR TITLE
disable link_adjustment if HTML is not well formed to be parsed by REXML

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ config.action_mailer.delivery_method = :letter_opener_web
 
 # If not everyone on the team is using vagrant
 config.action_mailer.delivery_method = ENV['USER'] == 'vagrant' ? :letter_opener_web : :letter_opener
+
+# If you receive errors from REXML parsing your HTML emails, you can use the following additional setting
+config.use_link_adjustment = false
 ```
 
 ## Usage on Heroku

--- a/app/models/letter_opener_web/letter.rb
+++ b/app/models/letter_opener_web/letter.rb
@@ -29,7 +29,7 @@ module LetterOpenerWeb
     def plain_text
       @plain_text ||= read_file(:plain)
       if use_link_adjustment
-        @plain_text ||= adjust_link_targets @plain_text
+        @plain_text = adjust_link_targets @plain_text
       end
     end
 
@@ -38,7 +38,10 @@ module LetterOpenerWeb
     end
 
     def rich_text
-      @rich_text ||= adjust_link_targets read_file(:rich)
+      @rich_text ||= read_file(:rich)
+      if use_link_adjustment
+        @rich_text = adjust_link_targets read_file(:rich)
+      end
     end
 
     def to_param

--- a/app/models/letter_opener_web/letter.rb
+++ b/app/models/letter_opener_web/letter.rb
@@ -31,6 +31,7 @@ module LetterOpenerWeb
       if use_link_adjustment
         @plain_text = adjust_link_targets @plain_text
       end
+      @plain_text
     end
 
     def use_link_adjustment
@@ -42,6 +43,7 @@ module LetterOpenerWeb
       if use_link_adjustment
         @rich_text = adjust_link_targets read_file(:rich)
       end
+      @rich_text
     end
 
     def to_param

--- a/app/models/letter_opener_web/letter.rb
+++ b/app/models/letter_opener_web/letter.rb
@@ -22,12 +22,19 @@ module LetterOpenerWeb
     end
 
     def initialize(params)
-      @id      = params.fetch(:id)
+      @id = params.fetch(:id)
       @sent_at = params[:sent_at]
     end
 
     def plain_text
-      @plain_text ||= adjust_link_targets read_file(:plain)
+      @plain_text ||= read_file(:plain)
+      if use_link_adjustment
+        @plain_text ||= adjust_link_targets @plain_text
+      end
+    end
+
+    def use_link_adjustment
+      Rails.configuration.use_link_adjustment
     end
 
     def rich_text
@@ -40,8 +47,8 @@ module LetterOpenerWeb
 
     def default_style
       style_exists?('rich') ?
-        'rich' :
-        'plain'
+          'rich' :
+          'plain'
     end
 
     def attachments
@@ -79,7 +86,7 @@ module LetterOpenerWeb
       # complain about it
       contents.scan(/<a\s[^>]+>(?:.|\s)*?<\/a>/).each do |link|
         fixed_link = fix_link_html(link)
-        xml        = REXML::Document.new(fixed_link).root
+        xml = REXML::Document.new(fixed_link).root
         unless xml.attributes['href'] =~ /(plain|rich).html/
           xml.attributes['target'] = '_blank'
           xml.add_text('') unless xml.text

--- a/letter_opener_web.gemspec
+++ b/letter_opener_web.gemspec
@@ -4,19 +4,19 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'letter_opener_web/version'
 
 Gem::Specification.new do |gem|
-  gem.name          = "letter_opener_web"
+  gem.name          = 'letter_opener_web'
   gem.version       = LetterOpenerWeb::VERSION
-  gem.authors       = ["Fabio Rehm"]
-  gem.email         = ["fgrehm@gmail.com"]
+  gem.authors       = ['Fabio Rehm']
+  gem.email         = ['fgrehm@gmail.com']
   gem.description   = %q{Gives letter_opener an interface for browsing sent emails}
   gem.summary       = gem.description
-  gem.homepage      = "https://github.com/fgrehm/letter_opener_web"
+  gem.homepage      = 'https://github.com/fgrehm/letter_opener_web'
   gem.license       = 'MIT'
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.require_paths = ["lib"]
+  gem.require_paths = ['lib']
 
   gem.add_dependency 'rails', '>= 3.2'
   gem.add_dependency 'letter_opener', '~> 1.0'

--- a/lib/letter_opener_web.rb
+++ b/lib/letter_opener_web.rb
@@ -1,4 +1,4 @@
-require "letter_opener_web/engine"
+require 'letter_opener_web/engine'
 require 'rexml/document'
 
 module LetterOpenerWeb

--- a/lib/letter_opener_web/delivery_method.rb
+++ b/lib/letter_opener_web/delivery_method.rb
@@ -4,8 +4,7 @@ module LetterOpenerWeb
   class DeliveryMethod < LetterOpener::DeliveryMethod
     def deliver!(mail)
       location = File.join(settings[:location], "#{Time.now.to_i}_#{Digest::SHA1.hexdigest(mail.encoded)[0..6]}")
-      messages = LetterOpener::Message.rendered_messages(location, mail)
-      # Launchy.open(URI.parse(URI.escape(messages.first.filepath)))
+      LetterOpener::Message.rendered_messages(location, mail)
     end
   end
 end

--- a/lib/letter_opener_web/engine.rb
+++ b/lib/letter_opener_web/engine.rb
@@ -12,10 +12,6 @@ module LetterOpenerWeb
       ActionMailer::Base.add_delivery_method :letter_opener_web, LetterOpenerWeb::DeliveryMethod, :location => Rails.root.join('tmp', 'letter_opener')
     end
 
-    initializer 'letter_opener_web.use_link_adjustment' do
-      Rails.configuration.use_link_adjustment = true
-    end
-
     initializer 'assets' do
       Rails.application.config.assets.precompile += %w(
         letter_opener_web/application.js

--- a/lib/letter_opener_web/engine.rb
+++ b/lib/letter_opener_web/engine.rb
@@ -8,11 +8,15 @@ module LetterOpenerWeb
   class Engine < ::Rails::Engine
     isolate_namespace LetterOpenerWeb
 
-    initializer "letter_opener_web.add_delivery_method" do
-      ActionMailer::Base.add_delivery_method :letter_opener_web, LetterOpenerWeb::DeliveryMethod, :location => Rails.root.join("tmp", "letter_opener")
+    initializer 'letter_opener_web.add_delivery_method' do
+      ActionMailer::Base.add_delivery_method :letter_opener_web, LetterOpenerWeb::DeliveryMethod, :location => Rails.root.join('tmp', 'letter_opener')
     end
 
-    initializer "assets" do |app|
+    initializer 'letter_opener_web.use_link_adjustment' do
+      Rails.configuration.use_link_adjustment = true
+    end
+
+    initializer 'assets' do
       Rails.application.config.assets.precompile += %w(
         letter_opener_web/application.js
         letter_opener_web/application.css

--- a/lib/letter_opener_web/version.rb
+++ b/lib/letter_opener_web/version.rb
@@ -1,3 +1,3 @@
 module LetterOpenerWeb
-  VERSION = '1.2.3'
+  VERSION = '1.2.4'
 end

--- a/lib/letter_opener_web/version.rb
+++ b/lib/letter_opener_web/version.rb
@@ -1,3 +1,3 @@
 module LetterOpenerWeb
-  VERSION = "1.2.3"
+  VERSION = '1.2.3'
 end


### PR DESCRIPTION
Hi Fabio,

I just made link_adjustment configurable via Rails.configuration.use_link_adjustment = false to avoid REXML to complain about badly formed HTML emails. If you like, pull it in.

Cheers
Michael
