### PR TITLE
Use railties as dependency rather than rails

### DIFF
--- a/letter_opener_web.gemspec
+++ b/letter_opener_web.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'rails', '>= 3.2'
+  gem.add_dependency 'railties', '>= 3.2'
   gem.add_dependency 'letter_opener', '~> 1.0'
 
   gem.add_development_dependency 'rspec-rails', '~> 3.0'


### PR DESCRIPTION
Some projects don't need ActiveRecord and other gems that are Rails dependencies and don't even depend on the "rails" gem.

The project I maintain is one of them. This increases the amount of gems it has to download but doesn't use them.
