### PR TITLE
Depend on the railties gem rather than the rails one

### DIFF
--- a/letter_opener_web.gemspec
+++ b/letter_opener_web.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'rails', '>= 3.2'
+  gem.add_dependency 'railties', '>= 3.2'
+  gem.add_dependency 'actionmailer', '>= 3.2'
   gem.add_dependency 'letter_opener', '~> 1.0'
 
   gem.add_development_dependency 'rspec-rails', '~> 3.0'


### PR DESCRIPTION
Some Rails projects do not rely on Rails, like those not using ActiveRecord. We shouldn't force those projects to download unnecessary gems.