### PR TITLE
Issue when attachments include "." or "&" characters

### DIFF
--- a/app/controllers/letter_opener_web/letters_controller.rb
+++ b/app/controllers/letter_opener_web/letters_controller.rb
@@ -18,7 +18,7 @@ module LetterOpenerWeb
 
     def attachment
       @letter = Letter.find(params[:id])
-      filename = "#{params[:file]}.#{params[:format]}"
+      filename = "#{params[:file]}"
 
       if file = @letter.attachments[filename]
         send_file(file, :filename => filename, :disposition => 'inline')

--- a/app/models/letter_opener_web/letter.rb
+++ b/app/models/letter_opener_web/letter.rb
@@ -91,7 +91,9 @@ module LetterOpenerWeb
 
     def fix_link_html(link_html)
       # REFACTOR: we need a better way of fixing the link inner html
-      link_html.dup.tap do |fixed_link|
+      output = link_html.dup
+
+      output.tap do |fixed_link|
         fixed_link.gsub!('<br>', '<br/>')
         fixed_link.scan(/<img(?:[^>]+?)>/).each do |img|
           fixed_img = img.dup
@@ -99,6 +101,11 @@ module LetterOpenerWeb
           fixed_link.gsub!(img, fixed_img)
         end
       end
+
+      # Replace the '&' symbol by html safe version
+      output.gsub!(/&(?!(?:amp|lt|gt|quot|apos);)/, '&amp;')
+
+      output
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,5 @@ LetterOpenerWeb::Engine.routes.draw do
   delete ':id'                   => 'letters#destroy',  :as => :delete_letter
   get    '/'                     => 'letters#index',    :as => :letters
   get    ':id(/:style)'          => 'letters#show',     :as => :letter
-  get    ':id/attachments/:file' => 'letters#attachment'
+  get    ':id/attachments/:file' => 'letters#attachment', constraints: { file: /[^\/]+/ }
 end

--- a/spec/controllers/letter_opener_web/letters_controller_spec.rb
+++ b/spec/controllers/letter_opener_web/letters_controller_spec.rb
@@ -72,9 +72,29 @@ describe LetterOpenerWeb::LettersController do
       allow(letter).to receive_messages(:exists? => true)
     end
 
+    context 'when file name include dot symbol' do
+      let(:file_name) { 'attached.image.jpg' }
+
+      it 'sends the file as an inline attachment' do
+        expect(controller).to receive(:send_file).with(attachment_path, :filename => file_name, :disposition => 'inline')
+        get :attachment, :id => id, :file => file_name
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "when file name include '&' symbol" do
+      let(:file_name) { 'image&file.jpg' }
+
+      it 'sends the file as an inline attachment' do
+        expect(controller).to receive(:send_file).with(attachment_path, :filename => file_name, :disposition => 'inline')
+        get :attachment, :id => id, :file => file_name
+        expect(response.status).to eq(200)
+      end
+    end
+
     it 'sends the file as an inline attachment' do
       expect(controller).to receive(:send_file).with(attachment_path, :filename => file_name, :disposition => 'inline')
-      get :attachment, :id => id, :file => file_name.gsub(/\.\w+/, ''), :format => File.extname(file_name)[1..-1]
+      get :attachment, :id => id, :file => file_name
       expect(response.status).to eq(200)
     end
 


### PR DESCRIPTION
Hey guys,

I very like to use this gem on staging environment. I found that if attachments include the "&" or "." symbols then it can't open a file.

I fixed it in this pull request. What do you think about it?
