### PR TITLE
Add configurable basic authentication

### DIFF
--- a/app/controllers/letter_opener_web/application_controller.rb
+++ b/app/controllers/letter_opener_web/application_controller.rb
@@ -1,4 +1,16 @@
 module LetterOpenerWeb
   class ApplicationController < ActionController::Base
+    before_action :authenticate!
+
+    private
+
+      def authenticate!
+        return unless LetterOpenerWeb.configuration.authentication_enabled
+
+        options = LetterOpenerWeb.configuration.authentication_options
+        authenticate_or_request_with_http_basic do |user, pass|
+          user == options[:user] && pass == options[:pass]
+        end
+      end
   end
 end

--- a/lib/letter_opener_web.rb
+++ b/lib/letter_opener_web.rb
@@ -1,5 +1,18 @@
 require "letter_opener_web/engine"
 require 'rexml/document'
+require 'letter_opener_web/configuration'
 
 module LetterOpenerWeb
+  class << self
+
+    attr_writer :configuration
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    def config
+      yield(configuration)
+    end
+  end
 end

--- a/lib/letter_opener_web/configuration.rb
+++ b/lib/letter_opener_web/configuration.rb
@@ -1,0 +1,10 @@
+module LetterOpenerWeb
+  class Configuration
+    # Whether you enable authentication or not
+    attr_accessor :authentication_enabled
+
+    # The options for authentication
+    # Now, only basic authentication is available
+    attr_accessor :authentication_options
+  end
+end

--- a/spec/controllers/letter_opener_web/application_controller_spec.rb
+++ b/spec/controllers/letter_opener_web/application_controller_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+describe LetterOpenerWeb::ApplicationController do
+  controller do
+    def index
+      render text: :ok
+    end
+  end
+
+  describe 'authenticate!' do
+    let(:user) { 'user' }
+    let(:pass) { 'pass' }
+
+    context 'authentication enabled' do
+      before do
+        LetterOpenerWeb.config do |config|
+          config.authentication_enabled = true
+          config.authentication_options = { user: user, pass: pass }
+        end
+
+        @request.env ||= {}
+        @request.env['HTTP_AUTHORIZATION'] =
+          ActionController::HttpAuthentication::Basic.encode_credentials(auth_user, auth_pass)
+
+        get :index
+      end
+
+      after do
+        LetterOpenerWeb.config do |config|
+          config.authentication_enabled = false
+          config.authentication_options = nil
+        end
+      end
+
+      context 'valid auth' do
+        let(:auth_user) { user }
+        let(:auth_pass) { pass }
+
+        it 'returns ok response' do
+          expect(response.body).to match(/ok/)
+        end
+      end
+
+      context 'invalid auth' do
+        let(:auth_user) { 'invalid_user' }
+        let(:auth_pass) { 'invalid_pass' }
+
+        it 'fails to get a success response' do
+          expect(response.body).to match(/HTTP Basic: Access denied/)
+        end
+      end
+    end
+
+    context 'authentication disabled' do
+      before do
+        get :index
+      end
+
+      it 'returns ok response' do
+        expect(response.body).to match(/ok/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I want to use basic authentication on letter_opener page.
To write an initializer like below, users can set basic authentication on letter_opener page.

config/initializers/letter_opener_web.rb

``` rb

LetterOpenerWeb.config do |config|
  config.authentication_enabled = true
  config.authentication_options = { user: 'authuser', pass: 'authpass' }
end
```

If documentations are needed, I'll write it on README or wiki.
