### PR TITLE
One location def to rule them all

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,3 @@ DEPENDENCIES
   rspec-rails (~> 3.0)
   rubocop
   shoulda-matchers (~> 2.5)
-
-BUNDLED WITH
-   1.12.5

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Check out http://letter-opener-web.herokuapp.com to see it in action.
 First add the gem to your development environment and run the `bundle` command to install it.
 
 ```ruby
-gem 'letter_opener_web', :group => :development
+group :development do
+  gem 'letter_opener_web'
+end
 ```
 
 ## Usage
@@ -50,6 +52,15 @@ config.action_mailer.delivery_method = :letter_opener_web
 
 # If not everyone on the team is using vagrant
 config.action_mailer.delivery_method = ENV['USER'] == 'vagrant' ? :letter_opener_web : :letter_opener
+```
+
+If you're using `:letter_opener_web` as your delivery method, you can change the location of the letters by adding the
+following to an initializer (or in development.rb):
+
+```ruby
+LetterOpenerWeb.configure do |config|
+  config.letters_location = Rails.root.join('your', 'new', 'path')
+end
 ```
 
 ## Usage on Heroku

--- a/app/models/letter_opener_web/letter.rb
+++ b/app/models/letter_opener_web/letter.rb
@@ -1,14 +1,19 @@
 # frozen_string_literal: true
 module LetterOpenerWeb
   class Letter
-    cattr_accessor :letters_location do
-      Rails.root.join('tmp', 'letter_opener')
-    end
-
     attr_reader :id, :sent_at
 
+    def self.letters_location
+      @letters_location ||= LetterOpenerWeb.config.letters_location
+    end
+
+    def self.letters_location=(directory)
+      LetterOpenerWeb.configure { |config| config.letters_location = directory }
+      @letters_location = nil
+    end
+
     def self.search
-      letters = Dir.glob("#{letters_location}/*").map do |folder|
+      letters = Dir.glob("#{LetterOpenerWeb.config.letters_location}/*").map do |folder|
         new(id: File.basename(folder), sent_at: File.mtime(folder))
       end
       letters.sort_by(&:sent_at).reverse
@@ -19,7 +24,7 @@ module LetterOpenerWeb
     end
 
     def self.destroy_all
-      FileUtils.rm_rf(letters_location)
+      FileUtils.rm_rf(LetterOpenerWeb.config.letters_location)
     end
 
     def initialize(params)
@@ -50,7 +55,7 @@ module LetterOpenerWeb
     end
 
     def delete
-      FileUtils.rm_rf("#{letters_location}/#{id}")
+      FileUtils.rm_rf("#{LetterOpenerWeb.config.letters_location}/#{id}")
     end
 
     def exists?
@@ -60,7 +65,7 @@ module LetterOpenerWeb
     private
 
     def base_dir
-      "#{letters_location}/#{id}"
+      "#{LetterOpenerWeb.config.letters_location}/#{id}"
     end
 
     def read_file(style)

--- a/lib/letter_opener_web.rb
+++ b/lib/letter_opener_web.rb
@@ -3,4 +3,21 @@ require 'letter_opener_web/engine'
 require 'rexml/document'
 
 module LetterOpenerWeb
+  class Config
+    attr_accessor :letters_location
+  end
+
+  def self.config
+    @config ||= Config.new.tap do |conf|
+      conf.letters_location = Rails.root.join('tmp', 'letter_opener')
+    end
+  end
+
+  def self.configure
+    yield config if block_given?
+  end
+
+  def self.reset!
+    @config = nil
+  end
 end

--- a/lib/letter_opener_web/engine.rb
+++ b/lib/letter_opener_web/engine.rb
@@ -13,7 +13,7 @@ module LetterOpenerWeb
       ActionMailer::Base.add_delivery_method(
         :letter_opener_web,
         LetterOpenerWeb::DeliveryMethod,
-        location: Rails.root.join('tmp', 'letter_opener')
+        location: LetterOpenerWeb::Letter.letters_location
       )
     end
 

--- a/lib/letter_opener_web/engine.rb
+++ b/lib/letter_opener_web/engine.rb
@@ -13,7 +13,7 @@ module LetterOpenerWeb
       ActionMailer::Base.add_delivery_method(
         :letter_opener_web,
         LetterOpenerWeb::DeliveryMethod,
-        location: LetterOpenerWeb::Letter.letters_location
+        location: LetterOpenerWeb.config.letters_location
       )
     end
 

--- a/spec/letter_opener_web_spec.rb
+++ b/spec/letter_opener_web_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe LetterOpenerWeb do
+  subject { described_class }
+  after(:each) { described_class.reset! }
+
+  describe '.config' do
+    it 'sets defaults' do
+      expected = Rails.root.join('tmp', 'letter_opener')
+      expect(subject.config.letters_location).to eq(expected)
+    end
+  end
+
+  describe '.configure' do
+    it 'yields config to the block' do
+      subject.configure do |config|
+        expect(config).to eq(subject.config)
+      end
+    end
+
+    it 'retains settings set within the block' do
+      subject.configure do |config|
+        config.letters_location = 'tmp/test_path'
+      end
+
+      expect(subject.config.letters_location).to eq('tmp/test_path')
+    end
+  end
+
+  describe '.reset!' do
+    it 'resets configuration' do
+      subject.configure do |config|
+        config.letters_location = 'tmp/test_path'
+      end
+
+      subject.reset!
+
+      expected = Rails.root.join('tmp', 'letter_opener')
+      expect(subject.config.letters_location).to eq(expected)
+    end
+  end
+end

--- a/spec/models/letter_opener_web/letter_spec.rb
+++ b/spec/models/letter_opener_web/letter_spec.rb
@@ -19,8 +19,7 @@ MAIL
   end
 
   before :each do
-    allow(described_class).to receive(:letters_location).and_return(location)
-    allow_any_instance_of(described_class).to receive(:letters_location).and_return(location)
+    LetterOpenerWeb.configure { |config| config.letters_location = location }
 
     %w(1111_1111 2222_2222).each do |folder|
       FileUtils.mkdir_p("#{location}/#{folder}")
@@ -34,6 +33,7 @@ MAIL
   end
 
   after :each do
+    LetterOpenerWeb.reset!
     FileUtils.rm_rf(location)
   end
 


### PR DESCRIPTION
Resolves #57 

When changing the default location for letters, it should be sufficient to set `LetterOpenerWeb::Letter.letters_location` in an initializer (or development.rb).

However, currently the engine hard codes the path, which is not ideal

@nicolas-besnard @josisusan would either of you be able to verify that this resolves the issue?