### PR TITLE
Support for Namespaced Mounting

### DIFF
--- a/app/views/letter_opener_web/letters/index.html.erb
+++ b/app/views/letter_opener_web/letters/index.html.erb
@@ -2,17 +2,17 @@
   <h1>
     Letters
     <span class="pull-right">
-      <%= link_to letter_opener_web.letters_path, class: 'btn refresh' do %>
+      <%= link_to letters_path, class: 'btn refresh' do %>
         <i class="icon-refresh"></i>
         Refresh
       <% end %>
-      <%= link_to letter_opener_web.clear_letters_path, method: 'delete', data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' do %>
+      <%= link_to clear_letters_path, method: 'delete', data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' do %>
         <i class="icon-trash icon-white"></i>
         Clear
       <% end %>
     </span>
   </h1>
-  <table class="table table-hover letter-opener" data-letters-path="<%= letter_opener_web.letters_path %>">
+  <table class="table table-hover letter-opener" data-letters-path="<%= letters_path %>">
     <thead>
       <tr>
         <th>ID</th>
@@ -24,11 +24,11 @@
       <% if first_letter = @letters.shift %>
         <tr class="active">
           <td>
-            <%= link_to(first_letter.id, letter_opener_web.letter_path(first_letter, style: first_letter.default_style), target: 'mail') %>
+            <%= link_to(first_letter.id, letter_path(first_letter, style: first_letter.default_style), target: 'mail') %>
           </td>
           <td><%= first_letter.sent_at %></td>
           <td>
-            <%= link_to letter_opener_web.delete_letter_path(first_letter), method: 'delete', data: { confirm: 'Are you sure you want to delete this email?' } do %>
+            <%= link_to delete_letter_path(first_letter), method: 'delete', data: { confirm: 'Are you sure you want to delete this email?' } do %>
               <span class="pull-right">
                 <i class="icon-remove-circle" title="Delete"></i>
               </span>
@@ -39,11 +39,11 @@
       <% @letters.each do |letter| %>
         <tr>
           <td>
-            <%= link_to(letter.id, letter_opener_web.letter_path(letter, style: letter.default_style), target: 'mail') %>
+            <%= link_to(letter.id, letter_path(letter, style: letter.default_style), target: 'mail') %>
           </td>
           <td><%= letter.sent_at %></td>
           <td>
-            <%= link_to letter_opener_web.delete_letter_path(letter), :method => 'delete', data: { confirm: 'Are you sure you want to delete this email?' } do %>
+            <%= link_to delete_letter_path(letter), :method => 'delete', data: { confirm: 'Are you sure you want to delete this email?' } do %>
               <span class="pull-right">
                 <i class="icon-remove-circle"></i>
               </span>
@@ -55,5 +55,5 @@
   </table>
 </div>
 <div class="col right">
-  <iframe name="mail" id="mail" src="<%= first_letter.present? ? letter_opener_web.letter_path(first_letter, style: first_letter.default_style) : 'about:blank' %>"></iframe>
+  <iframe name="mail" id="mail" src="<%= first_letter.present? ? letter_path(first_letter, style: first_letter.default_style) : 'about:blank' %>"></iframe>
 </div>


### PR DESCRIPTION
Currently if you mount letter_opener_web within a namespace, the URL helpers used in `letters#index` go :boom:

To try it out, update routes.rb as follows:

```ruby
Rails.application.routes.draw do
  namespace :inbox do
    mount LetterOpenerWeb::Engine => '/letter_opener'
  end
end
```

Without this PR, going to `/inbox/letter_opener` raises. With it, 🥅 