### PR TITLE
Lazy-load ActionMailer::Base to defer :action_mailer on_load hook

### DIFF
--- a/lib/letter_opener_web/engine.rb
+++ b/lib/letter_opener_web/engine.rb
@@ -7,11 +7,13 @@ module LetterOpenerWeb
     isolate_namespace LetterOpenerWeb
 
     initializer 'letter_opener_web.add_delivery_method' do
-      ActionMailer::Base.add_delivery_method(
-        :letter_opener_web,
-        LetterOpenerWeb::DeliveryMethod,
-        location: LetterOpenerWeb.config.letters_location
-      )
+      ActiveSupport.on_load :action_mailer do
+        ActionMailer::Base.add_delivery_method(
+          :letter_opener_web,
+          LetterOpenerWeb::DeliveryMethod,
+          location: LetterOpenerWeb.config.letters_location
+        )
+      end
     end
 
     initializer 'assets' do |_app|


### PR DESCRIPTION
This PR does exactly the same thing as https://github.com/ryanb/letter_opener/pull/89

Please don't directly touch ActionMailer::Base class in the initializer but use ActiveSupport on_load hook as documented here: http://api.rubyonrails.org/classes/ActiveSupport/LazyLoadHooks.html
