### PR TITLE
[add]routes for rails api mode

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,6 @@ LetterOpenerWeb::Engine.routes.draw do
   get    '/'                     => 'letters#index',    :as => :letters
   get    ':id(/:style)'          => 'letters#show',     :as => :letter
   get    ':id/attachments/:file' => 'letters#attachment'
+  post   'clear'                 => 'letters#clear'
+  post   ':id'                   => 'letters#destroy'
 end


### PR DESCRIPTION

This error occurred when using Rails API mode.

```
Started POST "/letter_opener/clear" for 172.18.0.1 at 2017-07-25 03:07:35 +0000
ActionController::RoutingError (No route matches [POST] "/letter_opener/clear"):
```

Plead add this routes.

```ruby
  post 'clear'                 => 'letters#clear'
  post ':id'                   => 'letters#destroy'
```

related. https://github.com/fgrehm/letter_opener_web/issues/42