### PR TITLE
Explicitly set `X-Frame-Options` header to `SAMEORIGIN` on `letters#show`.

### DIFF
--- a/app/controllers/letter_opener_web/letters_controller.rb
+++ b/app/controllers/letter_opener_web/letters_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 module LetterOpenerWeb
   class LettersController < ApplicationController
+    before_action :allow_same_origin, only: [:show]
     before_action :check_style, only: [:show]
     before_action :load_letter, only: [:show, :attachment, :destroy]
 
@@ -35,6 +36,10 @@ module LetterOpenerWeb
     end
 
     private
+
+    def allow_same_origin
+      response.headers["X-Frame-Options"] = "SAMEORIGIN"
+    end
 
     def check_style
       params[:style] = 'rich' unless %w(plain rich).include?(params[:style])

--- a/spec/controllers/letter_opener_web/letters_controller_spec.rb
+++ b/spec/controllers/letter_opener_web/letters_controller_spec.rb
@@ -38,6 +38,7 @@ describe LetterOpenerWeb::LettersController do
       it 'renders an HTML 200 response' do
         expect(response.status).to eq(200)
         expect(response.content_type).to eq('text/html')
+        expect(response.headers['X-Frame-Options']).to eq('SAMEORIGIN')
       end
     end
 

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -33,4 +33,8 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Strict frame settings to ensure appropriate endpoints work under tightened
+  # defaults.
+  config.action_dispatch.default_headers["X-Frame-Options"] = "DENY"
 end


### PR DESCRIPTION
This addresses the case where a Rails application has tightened default frame options, ensuring that `letter_opener_web` isn't mysteriously broken as a result.

CI may fail on rubocop checks -- running pre-push with my local rubocop (0.49.1) results in a slew of unrelated changes, unclear whether those should be included in a PR.