### PR TITLE
Fix All Them Rubocop Warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@
 AllCops:
   TargetRubyVersion: 2.3
   Exclude:
+    - "spec/dummy/bin/**/*"
     - "tmp/**/*"
     - "vendor/**/*"
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,10 @@ AllCops:
     - "tmp/**/*"
     - "vendor/**/*"
 
+# not available in older versions of Ruby
+Layout/IndentHeredoc:
+  Enabled: false
+
 Style/Documentation:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 source 'http://rubygems.org'
 
 # Declare your gem's dependencies in letter_opener_web.gemspec.

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,10 @@
 #!/usr/bin/env rake
 # frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 
 RuboCop::RakeTask.new
 RSpec::Core::RakeTask.new(:spec)
-task default: [:spec, :rubocop]
+task default: %i[spec rubocop]

--- a/app/controllers/letter_opener_web/application_controller.rb
+++ b/app/controllers/letter_opener_web/application_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module LetterOpenerWeb
   class ApplicationController < ActionController::Base
   end

--- a/app/controllers/letter_opener_web/letters_controller.rb
+++ b/app/controllers/letter_opener_web/letters_controller.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
+
 module LetterOpenerWeb
   class LettersController < ApplicationController
     before_action :check_style, only: [:show]
-    before_action :load_letter, only: [:show, :attachment, :destroy]
+    before_action :load_letter, only: %i[show attachment destroy]
 
     def index
       @letters = Letter.search
@@ -37,7 +38,7 @@ module LetterOpenerWeb
     private
 
     def check_style
-      params[:style] = 'rich' unless %w(plain rich).include?(params[:style])
+      params[:style] = 'rich' unless %w[plain rich].include?(params[:style])
     end
 
     def load_letter

--- a/app/models/letter_opener_web/letter.rb
+++ b/app/models/letter_opener_web/letter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module LetterOpenerWeb
   class Letter
     attr_reader :id, :sent_at

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 LetterOpenerWeb::Engine.routes.draw do
   delete 'clear'                 => 'letters#clear',    :as => :clear_letters
   delete ':id'                   => 'letters#destroy',  :as => :delete_letter

--- a/letter_opener_web.gemspec
+++ b/letter_opener_web.gemspec
@@ -1,5 +1,5 @@
-# -*- encoding: utf-8 -*-
 # frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'letter_opener_web/version'
@@ -19,9 +19,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'railties', '>= 3.2'
   gem.add_dependency 'actionmailer', '>= 3.2'
   gem.add_dependency 'letter_opener', '~> 1.0'
+  gem.add_dependency 'railties', '>= 3.2'
 
   gem.add_development_dependency 'rails', '~> 4.2.0'
   gem.add_development_dependency 'rspec-rails', '~> 3.0'

--- a/lib/letter_opener_web.rb
+++ b/lib/letter_opener_web.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'letter_opener_web/engine'
 require 'rexml/document'
 

--- a/lib/letter_opener_web/delivery_method.rb
+++ b/lib/letter_opener_web/delivery_method.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'letter_opener/delivery_method'
 
 module LetterOpenerWeb

--- a/lib/letter_opener_web/engine.rb
+++ b/lib/letter_opener_web/engine.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'letter_opener'
 require 'letter_opener_web/delivery_method'
 
@@ -15,13 +16,13 @@ module LetterOpenerWeb
     end
 
     initializer 'assets' do |_app|
-      Rails.application.config.assets.precompile += %w(
+      Rails.application.config.assets.precompile += %w[
         letter_opener_web/application.js
         letter_opener_web/application.css
         letter_opener_web/glyphicons-halflings.png
         letter_opener_web/glyphicons-halflings-white.png
         letter_opener_web/blue-dot.ico
-      )
+      ]
     end
   end
 end

--- a/lib/letter_opener_web/version.rb
+++ b/lib/letter_opener_web/version.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module LetterOpenerWeb
   VERSION = '1.3.1'
 end

--- a/spec/controllers/letter_opener_web/letters_controller_spec.rb
+++ b/spec/controllers/letter_opener_web/letters_controller_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 describe LetterOpenerWeb::LettersController do

--- a/spec/dummy/Rakefile
+++ b/spec/dummy/Rakefile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 end

--- a/spec/dummy/app/controllers/home_controller.rb
+++ b/spec/dummy/app/controllers/home_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class HomeController < ApplicationController
   def index; end
 

--- a/spec/dummy/app/helpers/application_helper.rb
+++ b/spec/dummy/app/helpers/application_helper.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
+
 module ApplicationHelper
 end

--- a/spec/dummy/app/mailers/application_mailer.rb
+++ b/spec/dummy/app/mailers/application_mailer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ApplicationMailer < ActionMailer::Base
   default from: 'from@example.com'
   layout 'mailer'

--- a/spec/dummy/app/mailers/contact_mailer.rb
+++ b/spec/dummy/app/mailers/contact_mailer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ContactMailer < ApplicationMailer
   default to: 'admin@letter_opener_web.org', from: 'no-reply@letter_opener_web.org'
 

--- a/spec/dummy/bin/bundle
+++ b/spec/dummy/bin/bundle
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 load Gem.bin_path('bundler', 'bundle')

--- a/spec/dummy/bin/rails
+++ b/spec/dummy/bin/rails
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+
 APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/spec/dummy/bin/rake
+++ b/spec/dummy/bin/rake
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/spec/dummy/bin/setup
+++ b/spec/dummy/bin/setup
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+
 require 'pathname'
 require 'fileutils'
 include FileUtils

--- a/spec/dummy/bin/update
+++ b/spec/dummy/bin/update
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+
 require 'pathname'
 require 'fileutils'
 include FileUtils

--- a/spec/dummy/config.ru
+++ b/spec/dummy/config.ru
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # This file is used by Rack-based servers to start the application.
 
 require_relative 'config/environment'

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'boot'
 
 require 'active_model/railtie'

--- a/spec/dummy/config/boot.rb
+++ b/spec/dummy/config/boot.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../Gemfile', __dir__)
 

--- a/spec/dummy/config/environment.rb
+++ b/spec/dummy/config/environment.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Load the Rails application.
 require_relative 'application'
 

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/spec/dummy/config/initializers/assets.rb
+++ b/spec/dummy/config/initializers/assets.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.

--- a/spec/dummy/config/initializers/cookies_serializer.rb
+++ b/spec/dummy/config/initializers/cookies_serializer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Specify a serializer for the signed and encrypted cookie jars.

--- a/spec/dummy/config/initializers/filter_parameter_logging.rb
+++ b/spec/dummy/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.

--- a/spec/dummy/config/initializers/new_framework_defaults.rb
+++ b/spec/dummy/config/initializers/new_framework_defaults.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 #
 # This file contains migration options to ease your Rails 5.0 upgrade.

--- a/spec/dummy/config/initializers/session_store.rb
+++ b/spec/dummy/config/initializers/session_store.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.session_store :cookie_store, key: '_dummy_session'

--- a/spec/dummy/config/initializers/wrap_parameters.rb
+++ b/spec/dummy/config/initializers/wrap_parameters.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/spec/dummy/config/puma.rb
+++ b/spec/dummy/config/puma.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers a minimum and maximum.
 # Any libraries that use thread pools should be configured to match

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Rails.application.routes.draw do
   mount LetterOpenerWeb::Engine => '/letter_opener'
 

--- a/spec/dummy/config/spring.rb
+++ b/spec/dummy/config/spring.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
-%w(
+
+%w[
   .ruby-version
   .rbenv-vars
   tmp/restart.txt
   tmp/caching-dev.txt
-).each { |path| Spring.watch(path) }
+].each { |path| Spring.watch(path) }

--- a/spec/letter_opener_web_spec.rb
+++ b/spec/letter_opener_web_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 describe LetterOpenerWeb do

--- a/spec/models/letter_opener_web/letter_spec.rb
+++ b/spec/models/letter_opener_web/letter_spec.rb
@@ -4,16 +4,16 @@ describe LetterOpenerWeb::Letter do
   let(:location) { File.expand_path('../../../tmp', __FILE__) }
 
   def rich_text(mail_id)
-    <<~MAIL
-      Rich text for #{mail_id}
-      <!DOCTYPE html>
-      <a href='a-link.html'>
-        <img src='an-image.jpg'>
-        Link text
-      </a>
-      <a href='fooo.html'>Bar</a>
-      <a href="example.html" class="blank"></a>
-      <address><a href="inside-address.html">inside address</a></address>
+    <<-MAIL
+Rich text for #{mail_id}
+<!DOCTYPE html>
+<a href='a-link.html'>
+  <img src='an-image.jpg'>
+  Link text
+</a>
+<a href='fooo.html'>Bar</a>
+<a href="example.html" class="blank"></a>
+<address><a href="inside-address.html">inside address</a></address>
 MAIL
   end
 

--- a/spec/models/letter_opener_web/letter_spec.rb
+++ b/spec/models/letter_opener_web/letter_spec.rb
@@ -1,25 +1,26 @@
 # frozen_string_literal: true
+
 describe LetterOpenerWeb::Letter do
   let(:location) { File.expand_path('../../../tmp', __FILE__) }
 
   def rich_text(mail_id)
-    <<-MAIL
-Rich text for #{mail_id}
-<!DOCTYPE html>
-<a href='a-link.html'>
-  <img src='an-image.jpg'>
-  Link text
-</a>
-<a href='fooo.html'>Bar</a>
-<a href="example.html" class="blank"></a>
-<address><a href="inside-address.html">inside address</a></address>
+    <<~MAIL
+      Rich text for #{mail_id}
+      <!DOCTYPE html>
+      <a href='a-link.html'>
+        <img src='an-image.jpg'>
+        Link text
+      </a>
+      <a href='fooo.html'>Bar</a>
+      <a href="example.html" class="blank"></a>
+      <address><a href="inside-address.html">inside address</a></address>
 MAIL
   end
 
   before :each do
     LetterOpenerWeb.configure { |config| config.letters_location = location }
 
-    %w(1111_1111 2222_2222).each do |folder|
+    %w[1111_1111 2222_2222].each do |folder|
       FileUtils.mkdir_p("#{location}/#{folder}")
       File.open("#{location}/#{folder}/plain.html", 'w') { |f| f.write("Plain text for #{folder}") }
       File.open("#{location}/#{folder}/rich.html", 'w')  { |f| f.write(rich_text(folder)) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../dummy/config/environment', __FILE__)
 require 'spec_helper'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'shoulda-matchers'
 
 RSpec.configure do |config|


### PR DESCRIPTION
Since there's a dependency on rubocop `~> 0.47` it gets updated on CI often. This is cool and expected, but does sometimes lead to issues where new branches that should pass CI, fail due to updated linting rules.

This updated all the warnings that were output by rubocop. (Mostly just `be rubocop -a`)