### PR TITLE
Disable Launchy using ENV variable instead of completely redefining `deliver!` method.

### DIFF
--- a/lib/letter_opener_web/delivery_method.rb
+++ b/lib/letter_opener_web/delivery_method.rb
@@ -5,8 +5,9 @@ require 'letter_opener/delivery_method'
 module LetterOpenerWeb
   class DeliveryMethod < LetterOpener::DeliveryMethod
     def deliver!(mail)
-      location = File.join(settings[:location], "#{Time.now.to_i}_#{Digest::SHA1.hexdigest(mail.encoded)[0..6]}")
-      LetterOpener::Message.rendered_messages(location, mail)
+      ENV['LAUNCHY_DRY_RUN'] = 'true'
+      super
+      ENV['LAUNCHY_DRY_RUN'] = 'false'
     end
   end
 end


### PR DESCRIPTION
Since a new version of `letter_opener` is released and there's a change in `LetterOpener::Message.rendered_messages` method (now we send location using `options` param) `letter_opener_web` is broken when `letter_opener_web` as delivery method is used (sorry about that). 

There's a bug report about it here https://github.com/ryanb/letter_opener/issues/147. I think it makes sense to disable Launchy using `LAUNCHY_DRY_RUN` env variable (https://github.com/copiousfreetime/launchy/blob/master/lib/launchy.rb#L15) to avoid future issues with compatibilities with `letter_opener` gem. What do you think?
