### PR TITLE
Fixed call to #rendered_messages

### DIFF
--- a/lib/letter_opener_web/delivery_method.rb
+++ b/lib/letter_opener_web/delivery_method.rb
@@ -6,7 +6,7 @@ module LetterOpenerWeb
   class DeliveryMethod < LetterOpener::DeliveryMethod
     def deliver!(mail)
       location = File.join(settings[:location], "#{Time.now.to_i}_#{Digest::SHA1.hexdigest(mail.encoded)[0..6]}")
-      LetterOpener::Message.rendered_messages(location, mail)
+      LetterOpener::Message.rendered_messages(mail, location: location)
     end
   end
 end


### PR DESCRIPTION
In this commit: https://github.com/ryanb/letter_opener/commit/e5fbf0f231d60e539ee8ddae4144226af63a4065#diff-2e20cc2a223324b62e266a1e07ce55e7

`LetterOpener::Message.rendered_messages` changed from...

```ruby
def self.rendered_messages(location, mail)
```

...to...

```ruby
def self.rendered_messages(mail, options = {})
```

`location` is now an option, and not an argument to the method.