### PR TITLE
Disable Launchy and ignore executable command detection

### DIFF
--- a/lib/letter_opener_web/delivery_method.rb
+++ b/lib/letter_opener_web/delivery_method.rb
@@ -5,9 +5,14 @@ require 'letter_opener/delivery_method'
 module LetterOpenerWeb
   class DeliveryMethod < LetterOpener::DeliveryMethod
     def deliver!(mail)
+      original = ENV['LAUNCHY_DRY_RUN']
       ENV['LAUNCHY_DRY_RUN'] = 'true'
+
       super
-      ENV['LAUNCHY_DRY_RUN'] = 'false'
+    rescue Launchy::CommandNotFoundError # rubocop:disable HandleExceptions
+      # Ignore for non-executable Launchy environment.
+    ensure
+      ENV['LAUNCHY_DRY_RUN'] = original
     end
   end
 end


### PR DESCRIPTION
When Launchy runs dry run mode, its runner will detect executable command.
Ref: https://github.com/copiousfreetime/launchy/blob/v2.4.3/lib/launchy/detect/runner.rb#L58

It makes sense for Launchy. So letter_opener_web should be avoid this error.

This PR follows up https://github.com/fgrehm/letter_opener_web/pull/73.