### PR TITLE
JSON API for listing messages and their metadata

### DIFF
--- a/app/controllers/letter_opener_web/letters_controller.rb
+++ b/app/controllers/letter_opener_web/letters_controller.rb
@@ -23,6 +23,11 @@ module LetterOpenerWeb
                     .gsub(/"plain\.html"/, "\"#{routes.letter_path(id: @letter.id, style: 'plain')}\"")
                     .gsub(/"rich\.html"/, "\"#{routes.letter_path(id: @letter.id, style: 'rich')}\"")
 
+      if params[:raw]
+        doc = Nokogiri::HTML(text)
+        text = doc.at('iframe').attr('srcdoc') rescue text
+      end
+
       render html: text.html_safe
     end
 

--- a/app/controllers/letter_opener_web/letters_controller.rb
+++ b/app/controllers/letter_opener_web/letters_controller.rb
@@ -9,6 +9,13 @@ module LetterOpenerWeb
 
     def index
       @letters = Letter.search
+
+      respond_to do |format|
+        format.html
+        format.json do
+          render json: @letters
+        end
+      end
     end
 
     def show

--- a/app/models/letter_opener_web/letter.rb
+++ b/app/models/letter_opener_web/letter.rb
@@ -2,7 +2,7 @@
 
 module LetterOpenerWeb
   class Letter
-    attr_reader :id, :sent_at
+    attr_reader :id, :sent_at, :subject
 
     def self.letters_location
       @letters_location ||= LetterOpenerWeb.config.letters_location
@@ -63,6 +63,27 @@ module LetterOpenerWeb
       File.exist?(base_dir)
     end
 
+    def subject
+      message_headers['Subject:']
+    end
+
+    def to
+      message_headers['To:']
+    end
+
+    def from
+      message_headers['From:']
+    end
+
+    def to_hash
+      {
+        from: from,
+        id: id,
+        subject: subject,
+        to: to,
+      }
+    end
+
     private
 
     def base_dir
@@ -103,6 +124,16 @@ module LetterOpenerWeb
           fixed_link.gsub!(img, fixed_img)
         end
       end
+    end
+
+    # Parse letter_openers special HTML header for metadata
+    def message_headers
+      headers = {}
+      doc = Nokogiri::HTML(read_file(default_style))
+      doc.css('#message_headers').search('dt').each do |node|
+        headers[node.text] = node.next_element.text
+      end
+      headers
     end
   end
 end

--- a/app/models/letter_opener_web/letter.rb
+++ b/app/models/letter_opener_web/letter.rb
@@ -2,7 +2,7 @@
 
 module LetterOpenerWeb
   class Letter
-    attr_reader :id, :sent_at, :subject
+    attr_reader :id, :sent_at
 
     def self.letters_location
       @letters_location ||= LetterOpenerWeb.config.letters_location
@@ -76,12 +76,7 @@ module LetterOpenerWeb
     end
 
     def to_hash
-      {
-        from: from,
-        id: id,
-        subject: subject,
-        to: to,
-      }
+      { from: from, id: id, subject: subject, to: to }
     end
 
     private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,6 @@ LetterOpenerWeb::Engine.routes.draw do
   delete 'clear'                 => 'letters#clear',    as: :clear_letters
   delete ':id'                   => 'letters#destroy',  as: :delete_letter
   get    '/(.:format)'           => 'letters#index',    as: :letters
-  get    ':id(/:style)'          => 'letters#show',     as: :letter
+  get    ':id(/:style)(/:raw)'   => 'letters#show',     as: :letter
   get    ':id/attachments/:file' => 'letters#attachment'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@
 LetterOpenerWeb::Engine.routes.draw do
   delete 'clear'                 => 'letters#clear',    as: :clear_letters
   delete ':id'                   => 'letters#destroy',  as: :delete_letter
-  get    '/'                     => 'letters#index',    as: :letters
+  get    '/(.:format)'           => 'letters#index',    as: :letters
   get    ':id(/:style)'          => 'letters#show',     as: :letter
   get    ':id/attachments/:file' => 'letters#attachment'
 end

--- a/letter_opener_web.gemspec
+++ b/letter_opener_web.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'letter_opener_web/version'
 

--- a/spec/controllers/letter_opener_web/letters_controller_spec.rb
+++ b/spec/controllers/letter_opener_web/letters_controller_spec.rb
@@ -94,6 +94,21 @@ describe LetterOpenerWeb::LettersController do
         expect(response.status).to eq(404)
       end
     end
+
+    context 'with raw parameter' do
+      let(:rich_text_with_iframe)  { '<iframe srcdoc="message here" />' }
+      let(:plain_text)             { 'plain text href="rich.html"' }
+      let(:letter)                 { double(:letter, rich_text: rich_text_with_iframe, plain_text: plain_text, id: id) }
+
+      fit 'should return HTML without iframe' do
+        expect(LetterOpenerWeb::Letter).to receive(:find).with(id).and_return(letter)
+        expect(letter).to receive(:exists?).and_return(true)
+
+        get :show, id: id, style: 'rich', raw: 'raw'
+        expect(response.status).to eq(200)
+        expect(response.body).not_to match(/iframe/)
+      end
+    end
   end
 
   describe 'GET attachment' do

--- a/spec/controllers/letter_opener_web/letters_controller_spec.rb
+++ b/spec/controllers/letter_opener_web/letters_controller_spec.rb
@@ -10,16 +10,36 @@ describe LetterOpenerWeb::LettersController do
   describe 'GET index' do
     before do
       allow(LetterOpenerWeb::Letter).to receive(:search)
-      get :index
     end
 
-    it 'searches for all letters' do
-      expect(LetterOpenerWeb::Letter).to have_received(:search)
+    context 'HTML' do
+      before do
+        get :index
+      end
+
+      it 'searches for all letters' do
+        expect(LetterOpenerWeb::Letter).to have_received(:search)
+      end
+
+      it 'returns an HTML 200 response' do
+        expect(response.status).to eq(200)
+        expect(response.content_type).to eq('text/html')
+      end
     end
 
-    it 'returns an HTML 200 response' do
-      expect(response.status).to eq(200)
-      expect(response.content_type).to eq('text/html')
+    context 'JSON' do
+      before do
+        get :index, format: :json
+      end
+
+      it 'searches for all letters' do
+        expect(LetterOpenerWeb::Letter).to have_received(:search)
+      end
+
+      it 'returns a JSON 200 response' do
+        expect(response.status).to eq(200)
+        expect(response.content_type).to eq('application/json')
+      end
     end
   end
 

--- a/spec/models/letter_opener_web/letter_spec.rb
+++ b/spec/models/letter_opener_web/letter_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe LetterOpenerWeb::Letter do
-  let(:location) { File.expand_path('../../../tmp', __FILE__) }
+  let(:location) { File.expand_path('../../tmp', __dir__) }
 
   def rich_text(mail_id)
     <<-MAIL
@@ -29,7 +29,7 @@ Rich text for #{mail_id}
 <a href='fooo.html'>Bar</a>
 <a href="example.html" class="blank"></a>
 <address><a href="inside-address.html">inside address</a></address>
-MAIL
+    MAIL
   end
 
   before :each do

--- a/spec/models/letter_opener_web/letter_spec.rb
+++ b/spec/models/letter_opener_web/letter_spec.rb
@@ -6,6 +6,21 @@ describe LetterOpenerWeb::Letter do
   def rich_text(mail_id)
     <<-MAIL
 Rich text for #{mail_id}
+<div id="message_headers">
+  <dl>
+    <dt>From:</dt>
+    <dd>App &lt;app@example.com&gt;</dd>
+
+    <dt>Subject:</dt>
+    <dd><strong>Welcome!</strong></dd>
+
+    <dt>Date:</dt>
+    <dd>Jul 11, 2018 12:21:25 PM EDT</dd>
+
+    <dt>To:</dt>
+    <dd>customer@example.com</dd>
+  </dl>
+</div>
 <!DOCTYPE html>
 <a href='a-link.html'>
   <img src='an-image.jpg'>
@@ -75,6 +90,33 @@ MAIL
     it 'returns plain if rich text version is not present' do
       allow(File).to receive_messages(exist?: false)
       expect(subject.default_style).to eq('plain')
+    end
+  end
+
+  describe 'subject' do
+    let(:id) { '1111_1111' }
+    subject { described_class.new(id: id) }
+
+    it 'returns subject from message' do
+      expect(subject.subject).to eq('Welcome!')
+    end
+  end
+
+  describe 'to' do
+    let(:id) { '1111_1111' }
+    subject { described_class.new(id: id) }
+
+    it 'returns address who was sent the message' do
+      expect(subject.to).to eq('customer@example.com')
+    end
+  end
+
+  describe 'from' do
+    let(:id) { '1111_1111' }
+    subject { described_class.new(id: id) }
+
+    it 'returns address who sent the message' do
+      expect(subject.from).to eq('App <app@example.com>')
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../dummy/config/environment', __FILE__)
+require File.expand_path('dummy/config/environment', __dir__)
 require 'spec_helper'
 require 'rspec/rails'
 


### PR DESCRIPTION
Adds a JSON API for listing messages and their metadata:

**GET /letter_opener.json**

```
[
  {
    "from": "App <notifications@example.com>",
    "id": "1531326085_772435_3ec1a42",
    "subject": "Retailer accepted your invitation!",
    "to": "Rebekah_Borer@gmail.com"
  },
  {
    "from": "App <notifications@example.com>",
    "id": "1531326065_158782_e7bf42c",
    "subject": "You have been invited to participate!",
    "to": "Laurie18@yahoo.com"
  }
]
```

Also:
*  Adds an optional `/raw` parameter to `LettersController#show` access a message without letter_opener's `iframe` wrapper.
* Fixes some Rubocop errors (not in my changes) that were preventing a push

This was adding to make end-to-end testing with Cypress, etc. easier.