### PR TITLE
Avoid require_dependency if Zeitwerk is enabled

### DIFF
--- a/app/controllers/letter_opener_web/letters_controller.rb
+++ b/app/controllers/letter_opener_web/letters_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-require_dependency 'letter_opener_web/application_controller'
+unless Rails.respond_to?(:autoloaders) && Rails.autoloaders.zeitwerk_enabled?
+  require_dependency 'letter_opener_web/application_controller'
+end
 
 module LetterOpenerWeb
   class LettersController < ApplicationController


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/37599

That `require_dependency` is here to workaround a limitation in Rails's Classic autoloader ([as explained here](https://guides.rubyonrails.org/v5.1.4/autoloading_and_reloading_constants.html#when-constants-aren-t-missed-qualified-references)).

Since Rails 6, there's a new autoloader available, which doesn't have this limitation, as well as an option to not add autoloaded paths to the global `$LOAD_PATH`.

That later option breaks `latter_opener_web`.

@pseudomuto @rafaelfranca @Edouard-Chin @etiennebarrie