### PR TITLE
CI: Drop unused sudo: false directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: ruby
 
 rvm:


### PR DESCRIPTION
This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).