### PR TITLE
Add rexml gem into dependency for Ruby 3.0

### DIFF
--- a/letter_opener_web.gemspec
+++ b/letter_opener_web.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'actionmailer', '>= 3.2'
   gem.add_dependency 'letter_opener', '~> 1.0'
   gem.add_dependency 'railties', '>= 3.2'
+  gem.add_dependency 'rexml'
 
   gem.add_development_dependency 'rails', '~> 5.0'
   gem.add_development_dependency 'rspec-rails', '~> 3.0'


### PR DESCRIPTION
It has been removed from default gems since Ruby 3.0.
Ref: https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/

To use it via bundler, we should specify it as dependency.