### PR TITLE
Explicit `Letter` class for avoiding name conflict

### DIFF
--- a/app/controllers/letter_opener_web/letters_controller.rb
+++ b/app/controllers/letter_opener_web/letters_controller.rb
@@ -10,7 +10,7 @@ module LetterOpenerWeb
     before_action :load_letter, only: %i[show attachment destroy]
 
     def index
-      @letters = Letter.search
+      @letters = LetterOpenerWeb::Letter.search
     end
 
     def show
@@ -31,7 +31,7 @@ module LetterOpenerWeb
     end
 
     def clear
-      Letter.destroy_all
+      LetterOpenerWeb::Letter.destroy_all
       redirect_to routes.letters_path
     end
 
@@ -47,7 +47,7 @@ module LetterOpenerWeb
     end
 
     def load_letter
-      @letter = Letter.find(params[:id])
+      @letter = LetterOpenerWeb::Letter.find(params[:id])
       head :not_found unless @letter.exists?
     end
 


### PR DESCRIPTION
I installed letter_opener_web in my rails app, I found conflicting `Letter` class with my own `Letter` class.

I'd like to explicit `Letter` class's name space in `letter_opener_web`.
If there is other solutions without changing `letter_opener_web`, I'd like to choose that.