### PR TITLE
Add Rails' built-in CSRF protection

### DIFF
--- a/app/controllers/letter_opener_web/application_controller.rb
+++ b/app/controllers/letter_opener_web/application_controller.rb
@@ -2,5 +2,6 @@
 
 module LetterOpenerWeb
   class ApplicationController < ActionController::Base
+    protect_from_forgery with: :exception
   end
 end


### PR DESCRIPTION
The HTML contains the anti-CSRF token in https://github.com/fgrehm/letter_opener_web/blob/feea82d0b279bfabe8e61891eecdc6098287f77e/app/views/layouts/letter_opener_web/letters.html.erb#L9 however the `protect_from_forgery` call was missing from `ApplicationController`.