### PR TITLE
Require `rails_helper` instead of `spec_helper` on rspec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,4 @@
 --order rand
 --color
 --format progress
---require spec_helper
+--require rails_helper


### PR DESCRIPTION
rails_helper is an actual entry point of specs.
This change allows developers to running single spec like the following:
```
$ bundle exec rspec spec/models/letter_opener_web/letter_spec.rb
```

Without this change, the following error will be occurred:
```
$ bundle exec rspec spec/models/letter_opener_web/letter_spec.rb

An error occurred while loading ./spec/models/letter_opener_web/letter_spec.rb.
Failure/Error:
  RSpec.describe LetterOpenerWeb::Letter do
    let(:location) { Pathname.new(__dir__).join('..', '..', 'tmp').cleanpath }

...

NameError:
  uninitialized constant LetterOpenerWeb::Letter
```