### PR TITLE
[Refactor] Remove "next" branch from CI target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master, next ]
+    branches: [ master ]
 
 jobs:
   test:


### PR DESCRIPTION
This branch was specified as CI target in https://github.com/fgrehm/letter_opener_web/pull/114/commits/104bd2f39e3aa664e5fbfa90689fdc20aef9c77c.
However, "next" has been merged into "master" branch in https://github.com/fgrehm/letter_opener_web/pull/113.