### PR TITLE
Support Rails 7 (relax the upper limit of dependencies on Rails)

### DIFF
--- a/letter_opener_web.gemspec
+++ b/letter_opener_web.gemspec
@@ -20,12 +20,12 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'actionmailer', '>= 5.2'
+  gem.add_dependency 'actionmailer', '>= 5.2', '< 8'
   gem.add_dependency 'letter_opener', '~> 1.7'
-  gem.add_dependency 'railties', '>= 5.2'
+  gem.add_dependency 'railties', '>= 5.2', '< 8'
   gem.add_dependency 'rexml'
 
-  gem.add_development_dependency 'rails', '~> 6.1'
+  gem.add_development_dependency 'rails', '~> 6.1', '< 8'
   gem.add_development_dependency 'rspec-rails', '~> 5.0'
   gem.add_development_dependency 'rubocop', '~> 1.22'
   gem.add_development_dependency 'rubocop-rails', '~> 2.12'


### PR DESCRIPTION
Since no major changes related to actionmailer in rails 7.
We should only relax the upper limit with less than future major Rails release.