### PR TITLE
Strip Attachment elements from sidebar

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,3 +18,7 @@ Style/Documentation:
     - 'lib/letter_opener_web.rb'
     - 'lib/letter_opener_web/delivery_method.rb'
     - 'lib/letter_opener_web/engine.rb'
+
+Metrics/ClassLength:
+  Exclude:
+    - 'app/models/letter_opener_web/letter.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased](https://github.com/fgrehm/letter_opener_web/compare/v2.0.0...master)
+
+  - Reliably strip Attachment links from the sidebar. [#132](https://github.com/fgrehm/letter_opener_web/pull/132)
+
 ## [v2.0.0](https://github.com/fgrehm/letter_opener_web/compare/v1.4.1...v2.0.0)
 
   - Require Rails >= 5.2, run tests against Rails 6.1 [#113](https://github.com/fgrehm/letter_opener_web/pull/113)

--- a/app/models/letter_opener_web/letter.rb
+++ b/app/models/letter_opener_web/letter.rb
@@ -81,10 +81,13 @@ module LetterOpenerWeb
 
     def remove_attachments_link(headers)
       xml = REXML::Document.new(headers)
-      if xml.root.elements.size == 10
-        xml.delete_element('//dd[last()]')
-        xml.delete_element('//dt[last()]')
+      label_element = xml.root.elements.find { |e| e.get_text&.value&.match?(/attachments:/i) }
+
+      if label_element
+        xml.root.delete_element(label_element.next_element) # the list of attachments
+        xml.root.delete_element(label_element)
       end
+
       xml.to_s
     end
 


### PR DESCRIPTION
The count of elements is (or at least can be) different depending on the email headers - like reply-to, etc… So rather than relying on the count and stripping the last two, find the `<dt>` containing the "Attachments:" label text, and then remove it and the element following it.

Here's what it looks like with this patch applied. Note the Attachments aren't in the sidebar, but still show up in the iframe.

<img width="751" alt="snap-2024-04-19-12 26 52" src="https://github.com/fgrehm/letter_opener_web/assets/48658/1bfd942e-5a0f-44ed-be85-dc85bf677903">

(This is replacing #132 which is the same change, but I deleted the remote. Yay me! Yay Git!)