### PR TITLE
Bump rexml to v3.3.2

### DIFF
--- a/letter_opener_web.gemspec
+++ b/letter_opener_web.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'actionmailer', '>= 6.1'
   gem.add_dependency 'letter_opener', '~> 1.9'
   gem.add_dependency 'railties', '>= 6.1'
-  gem.add_dependency 'rexml'
+  gem.add_dependency 'rexml', '~> 3.3.2'
 
   gem.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
The REXML gem before 3.3.1 has some DoS vulnerabilities when it parses an XML that has many specific characters such as `<`, `0` and `%>`.

The REXML gem 3.3.2 or later include the patches to fix these vulnerabilities.

https://github.com/ruby/rexml/security/advisories/GHSA-4xqq-m2hx-25v8