### PR TITLE
Exclude spec files from gem package

### DIFF
--- a/letter_opener_web.gemspec
+++ b/letter_opener_web.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.license               = 'MIT'
   gem.required_ruby_version = '>= 3.1'
 
-  gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
+  gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR).grep_v(%r{^spec/})
   gem.executables   = gem.files.grep(%r{^exe/}).map { |f| File.basename(f) }
   gem.require_paths = ['lib']
 


### PR DESCRIPTION
Here's a patch that excludes files under spec directory from the gem package.

With this patch, the gem package size shrinks as follows:
```
before: 92160 bytes
after:  78336 bytes
```
