### PR TITLE
Fix sidebar list items width

### DIFF
--- a/app/views/letter_opener_web/letters/index.html.erb
+++ b/app/views/letter_opener_web/letters/index.html.erb
@@ -11,7 +11,7 @@
     </span>
   </h1>
     <div class="letter-opener" data-letters-path="<%= letters_path %>">
-      <ul class="list-group rounded-0 pt-2">
+      <ul class="list-group w-100 rounded-0 pt-2">
         <% if first_letter = @letters.shift %>
           <%= render partial: "item", locals: { letter: first_letter, active: true } %>
         <% end %>


### PR DESCRIPTION
The sidebar list items are not full width. I guess it also fixes this https://github.com/fgrehm/letter_opener_web/issues/126

Before:

   ![image](https://github.com/user-attachments/assets/42fe5b26-0259-4948-b658-7d170e135367)

---

After:

  ![image](https://github.com/user-attachments/assets/9cbd3bbc-92ed-430b-9873-7ff8ba2a8b1b)
