### PR TITLE
Add Rails CSP nonce for styles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ source 'http://rubygems.org'
 gemspec
 
 group :development do
+  gem 'concurrent-ruby', '= 1.3.4'
   gem 'rails', '~> 6.1'
   gem 'rspec-rails', '~> 5.0'
   gem 'rubocop', '~> 1.22'

--- a/app/views/layouts/letter_opener_web/styles/_bootstrap.html.erb
+++ b/app/views/layouts/letter_opener_web/styles/_bootstrap.html.erb
@@ -1,4 +1,4 @@
-<style>
+<style nonce="<%= content_security_policy_nonce %>">
 @charset "UTF-8";/*!
  * Bootstrap v5.1.1 (https://getbootstrap.com/)
  * Copyright 2011-2021 The Bootstrap Authors

--- a/app/views/layouts/letter_opener_web/styles/_letters.html.erb
+++ b/app/views/layouts/letter_opener_web/styles/_letters.html.erb
@@ -1,4 +1,4 @@
-<style>
+<style nonce="<%= content_security_policy_nonce %>">
   @media (prefers-color-scheme: dark) {
       body {
           background-color: black;


### PR DESCRIPTION
Hello @fgrehm,

`script` tags already include `nonce` for configured CSP but not `style` tags.
Even though `nonce` are necessary with the following Rails CSP configuration.

```ruby
Rails.application.configure do
  config.content_security_policy do |policy|
    # ...
    policy.script_src :self
    policy.style_src :self
  end
  config.content_security_policy_nonce_directives = %w[script-src style-src]
end
```
This PR adds nonce to `style` tags.