### PR TITLE
Improve the CI matrix to run tests on multiple Rails versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,34 @@ on:
     branches: [ master ]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby 3.4
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+
+      - name: Lint with Rubocop
+        run: bundle exec rubocop
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby 3.4
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+
+      - name: Build gem
+        run: bundle exec rake build
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -16,7 +44,23 @@ jobs:
           - "3.1"
           - "3.2"
           - "3.3"
+          - "3.4"
           - truffleruby-head
+        rails-version:
+          - "6_1"
+          - "7_0"
+          - "7_1"
+          - "7_2"
+          - "8_0"
+        exclude:
+          - ruby-version: "3.4"
+            rails-version: "6_1"
+          - ruby-version: "3.4"
+            rails-version: "7_0"
+          - ruby-version: "3.1"
+            rails-version: "8_0"
+    env:
+      BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails-version }}.gemfile
 
     steps:
       - uses: actions/checkout@v4
@@ -27,14 +71,5 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
 
-      - name: Install dependencies
-        run: bundle install
-
-      - name: Lint with Rubocop
-        run: bin/rubocop
-
       - name: Run tests
         run: bin/rspec
-
-      - name: Build gem
-        run: bin/rake build

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ test/tmp
 test/version_tmp
 tmp
 Gemfile.lock
+gemfiles/*.lock
 

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source 'http://rubygems.org'
+
+gemspec path: '../'
+
+gem 'concurrent-ruby', '< 1.3.5'
+gem 'rails', '~> 6.1.0'
+gem 'rspec-rails', '~> 5.1.0'

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source 'http://rubygems.org'
+
+gemspec path: '../'
+
+gem 'concurrent-ruby', '< 1.3.5'
+gem 'rails', '~> 7.0.0'
+gem 'rspec-rails', '~> 6.0.0'

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source 'http://rubygems.org'
+
+gemspec path: '../'
+
+gem 'rails', '~> 7.1.0'
+gem 'rspec-rails', '~> 6.1.0'

--- a/gemfiles/rails_7_2.gemfile
+++ b/gemfiles/rails_7_2.gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source 'http://rubygems.org'
+
+gemspec path: '../'
+
+gem 'rails', '~> 7.2.0'
+gem 'rspec-rails', '~> 6.1.0'

--- a/gemfiles/rails_8_0.gemfile
+++ b/gemfiles/rails_8_0.gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source 'http://rubygems.org'
+
+gemspec path: '../'
+
+gem 'rails', '~> 8.0.0'
+gem 'rspec-rails', '~> 7.1.0'


### PR DESCRIPTION
Created a matrix with the supported Ruby and Rails versions to expand CI coverage

Test result is [here](https://github.com/willnet/letter_opener_web/actions/runs/16537492710).