### PR TITLE
Add pluggable storage backend support (Enabling Redis/S3 storage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,11 @@ end
 
 ### Using on Heroku / Multi-Machine Environments
 
-For Heroku or other multi-machine/multi-dyno environments, use the Redis storage backend:
+For Heroku or other multi-machine/multi-dyno environments, use alternative storage backends:
 
-**[letter_opener_web-redis](https://github.com/WizaCo/letter_opener_web-redis)** - Stores emails in Redis instead of the filesystem, making it work seamlessly across multiple dynos/machines and with background jobs.
+**[letter_opener_web-redis](https://github.com/WizaCo/letter_opener_web-redis)** - Stores emails in Redis.
+
+**[letter_opener_web-s3](https://github.com/WizaCo/letter_opener_web-s3)** - Stores emails in Amazon S3.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -87,9 +87,11 @@ Your::Application.routes.draw do
 end
 ```
 
-**NOTICE: Using this gem on Heroku will only work if your app has just one Dyno
-and does not send emails from background jobs. For updates on this matter please
-subscribe to [GH-35](https://github.com/fgrehm/letter_opener_web/issues/35)**
+### Using on Heroku / Multi-Machine Environments
+
+For Heroku or other multi-machine/multi-dyno environments, use the Redis storage backend:
+
+**[letter_opener_web-redis](https://github.com/WizaCo/letter_opener_web-redis)** - Stores emails in Redis instead of the filesystem, making it work seamlessly across multiple dynos/machines and with background jobs.
 
 ## Acknowledgements
 

--- a/app/controllers/letter_opener_web/letters_controller.rb
+++ b/app/controllers/letter_opener_web/letters_controller.rb
@@ -10,7 +10,7 @@ module LetterOpenerWeb
     before_action :load_letter, only: %i[show attachment destroy]
 
     def index
-      @letters = LetterOpenerWeb::Letter.search
+      @letters = letter_class.search
     end
 
     def show
@@ -23,15 +23,14 @@ module LetterOpenerWeb
 
     def attachment
       filename = params[:file]
-      file     = @letter.attachments[filename]
 
-      return render plain: 'Attachment not found!', status: 404 unless file.present?
+      return render plain: 'Attachment not found!', status: 404 unless @letter.attachments.key?(filename)
 
-      send_file(file, filename: filename, disposition: 'inline')
+      @letter.send_attachment(self, filename)
     end
 
     def clear
-      LetterOpenerWeb::Letter.destroy_all
+      letter_class.destroy_all
       redirect_to routes.letters_path
     end
 
@@ -50,13 +49,17 @@ module LetterOpenerWeb
     end
 
     def load_letter
-      @letter = LetterOpenerWeb::Letter.find(params[:id])
+      @letter = letter_class.find(params[:id])
 
       head :not_found unless @letter.valid?
     end
 
     def routes
       LetterOpenerWeb.railtie_routes_url_helpers
+    end
+
+    def letter_class
+      LetterOpenerWeb.config.letter_class
     end
   end
 end

--- a/app/models/letter_opener_web/letter.rb
+++ b/app/models/letter_opener_web/letter.rb
@@ -1,8 +1,14 @@
 # frozen_string_literal: true
 
+require 'letter_opener_web/letter_interface'
+
 module LetterOpenerWeb
+  # Default file-based Letter implementation
+  #
+  # This is the original file-based storage implementation that reads
+  # letters from the local filesystem.
   class Letter
-    attr_reader :id, :sent_at
+    include LetterInterface
 
     def self.letters_location
       @letters_location ||= LetterOpenerWeb.config.letters_location
@@ -75,6 +81,13 @@ module LetterOpenerWeb
 
     def valid?
       exists? && base_dir_within_letters_location?
+    end
+
+    def send_attachment(controller, filename)
+      file_path = attachments[filename]
+      return unless file_path
+
+      controller.send_file(file_path, filename: filename, disposition: 'inline')
     end
 
     private

--- a/lib/letter_opener_web.rb
+++ b/lib/letter_opener_web.rb
@@ -7,10 +7,11 @@ require 'rexml/document'
 
 module LetterOpenerWeb
   class Config
-    attr_accessor :letters_location, :letter_class
+    attr_accessor :letters_location
+    attr_writer :letter_class
 
-    def initialize
-      @letter_class = LetterOpenerWeb::Letter
+    def letter_class
+      @letter_class ||= LetterOpenerWeb::Letter
     end
   end
 

--- a/lib/letter_opener_web.rb
+++ b/lib/letter_opener_web.rb
@@ -2,11 +2,16 @@
 
 require 'letter_opener_web/version'
 require 'letter_opener_web/engine'
+require 'letter_opener_web/letter_interface'
 require 'rexml/document'
 
 module LetterOpenerWeb
   class Config
-    attr_accessor :letters_location
+    attr_accessor :letters_location, :letter_class
+
+    def initialize
+      @letter_class = LetterOpenerWeb::Letter
+    end
   end
 
   def self.config

--- a/lib/letter_opener_web/letter_interface.rb
+++ b/lib/letter_opener_web/letter_interface.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module LetterOpenerWeb
+  # Interface that all Letter storage implementations must implement
+  #
+  # This module defines the contract for Letter storage backends.
+  # Any storage implementation (file-based, S3, Redis, etc.) must provide
+  # all the methods defined in this interface.
+  module LetterInterface
+    extend ActiveSupport::Concern
+
+    included do
+      # Ensure the implementing class defines required attributes
+      attr_reader :id, :sent_at
+    end
+
+    class_methods do
+      # Returns all letters sorted by sent_at (newest first)
+      #
+      # @return [Array<Letter>] Array of letter instances
+      def search
+        raise NotImplementedError, "#{self} must implement .search"
+      end
+
+      # Find a letter by its ID
+      #
+      # @param id [String] The letter identifier
+      # @return [Letter] A letter instance
+      def find(id)
+        raise NotImplementedError, "#{self} must implement .find"
+      end
+
+      # Destroy all letters
+      #
+      # @return [void]
+      def destroy_all
+        raise NotImplementedError, "#{self} must implement .destroy_all"
+      end
+    end
+
+    # Returns the email headers as a hash
+    #
+    # @return [Hash] Email headers (from, to, subject, etc.)
+    def headers
+      raise NotImplementedError, "#{self.class} must implement #headers"
+    end
+
+    # Returns the plain text version of the email
+    #
+    # @return [String] Plain text email content
+    def plain_text
+      raise NotImplementedError, "#{self.class} must implement #plain_text"
+    end
+
+    # Returns the HTML version of the email
+    #
+    # @return [String] HTML email content
+    def rich_text
+      raise NotImplementedError, "#{self.class} must implement #rich_text"
+    end
+
+    # Returns a hash of attachment filenames to their paths/URLs
+    #
+    # @return [Hash{String => String}] Mapping of filename to path/URL
+    def attachments
+      raise NotImplementedError, "#{self.class} must implement #attachments"
+    end
+
+    # Send the attachment to the controller
+    #
+    # @param controller [ActionController::Base] The controller instance
+    # @param filename [String] The attachment filename
+    # @return [void]
+    def send_attachment(controller, filename)
+      raise NotImplementedError, "#{self.class} must implement #send_attachment"
+    end
+
+    # Delete this letter
+    #
+    # @return [void]
+    def delete
+      raise NotImplementedError, "#{self.class} must implement #delete"
+    end
+
+    # Check if this letter is valid and accessible
+    #
+    # @return [Boolean]
+    def valid?
+      raise NotImplementedError, "#{self.class} must implement #valid?"
+    end
+  end
+end

--- a/spec/controllers/letter_opener_web/letters_controller_spec.rb
+++ b/spec/controllers/letter_opener_web/letters_controller_spec.rb
@@ -89,24 +89,21 @@ RSpec.describe LetterOpenerWeb::LettersController do
 
     context 'when the file exists' do
       before do
-        # Stub a 200 response b/c `send_file` will 204 when the file doesn't actually exist
-        allow(controller).to receive(:send_file) { controller.head :ok }
+        allow(letter).to receive(:send_attachment) { controller.head :ok }
       end
 
       it 'sends the file as an inline attachment' do
         get :attachment, params: { id: id, file: file_name }
 
         expect(response.status).to eq(200)
-        expect(controller).to have_received(:send_file)
-          .with(attachment_path, filename: file_name, disposition: 'inline')
+        expect(letter).to have_received(:send_attachment).with(controller, file_name)
       end
 
       context 'when file name includes a dot' do
         let(:file_name) { 'image.dot.jpg' }
 
         it 'sends the file as an inline attachment' do
-          expect(controller).to receive(:send_file).with(attachment_path, filename: file_name,
-                                                                          disposition: 'inline')
+          expect(letter).to receive(:send_attachment).with(controller, file_name) { controller.head :ok }
           get :attachment, params: { id: id, file: file_name }
           expect(response.status).to eq(200)
         end


### PR DESCRIPTION
Adds support for pluggable storage backends via configuration, enabling external gems like `letter_opener_web-redis` and `letter_opener_web-s3` to provide alternative storage implementations.

  ## Changes
  - Added `LetterInterface` module defining the contract for storage backends
  - Added `letter_class` configuration option (defaults to `LetterOpenerWeb::Letter`)
  - Updated `LettersController` to use configured `letter_class` instead of hardcoded `Letter`
  - Updated `Letter` to implement `send_attachment` method for consistency
  - Updated README with information about Redis backend for Heroku/multi-machine environments

  ## Usage
  Storage backends can now be swapped via configuration:
```ruby
  require 'letter_opener_web_redis'

  LetterOpenerWeb.configure do |config|
    config.letter_class = LetterOpenerWeb::RedisLetter
    config.redis_url = ENV['REDIS_URL']
    config.redis_namespace = 'letter_opener'
  end

  config.action_mailer.delivery_method = :letter_opener_web_redis
```

Redis storage available here:  https://github.com/WizaCo/letter_opener_web-redis
S3: https://github.com/WizaCo/letter_opener_web-s3