### PR TITLE
Make dark-mode inversion optional (configurable)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,10 @@ jobs:
             rails-version: "7_0"
           - ruby-version: "3.1"
             rails-version: "8_0"
+          - ruby-version: truffleruby-head
+            rails-version: "6_1"
+          - ruby-version: truffleruby-head
+            rails-version: "7_0"
     env:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails-version }}.gemfile
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased](https://github.com/fgrehm/letter_opener_web/compare/v3.0.0...master)
 
+### Additions
+- Make dark mode color inversion optional via `LetterOpenerWeb.config.auto_dark_mode` (default: `false`).  
+  This avoids double-inversion issues for email templates that already implement `prefers-color-scheme`. [#146]
+
 ## [3.0.0](https://github.com/fgrehm/letter_opener_web/compare/v2.0.0...v3.0.0)
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ your delivery method on your `config/environments/development.rb`:
 config.action_mailer.delivery_method = :letter_opener_web
 ```
 
+## Configuration
+
+### letters_location
+
 If you're using `:letter_opener_web` as your delivery method, you can change the location of
 the letters by adding the following to an initializer (or in `development.rb`):
 
@@ -58,6 +62,24 @@ LetterOpenerWeb.configure do |config|
   config.letters_location = Rails.root.join('your', 'new', 'path')
 end
 ```
+
+### auto_dark_mode
+
+You can control whether LetterOpenerWeb applies an automatic dark mode
+color inversion strategy when previewing emails.
+
+By default, this is disabled to avoid conflicts with email templates that
+already implement their own `prefers-color-scheme` styling.
+
+```ruby
+LetterOpenerWeb.configure do |config|
+  config.auto_dark_mode = true
+end
+```
+
+When enabled, LetterOpenerWeb applies a CSS-based inversion strategy to
+approximate dark mode for templates that do not define their own styles,
+similar to high-contrast or browser-level color inversion.
 
 ## Usage on pre-production environments
 

--- a/app/views/layouts/letter_opener_web/styles/_letters.html.erb
+++ b/app/views/layouts/letter_opener_web/styles/_letters.html.erb
@@ -1,12 +1,14 @@
 <style>
-  @media (prefers-color-scheme: dark) {
-      body {
-          background-color: black;
-      }
-      .left, .right {
-          filter: invert(1) hue-rotate(180deg);
-      }
-  }
+  <% if LetterOpenerWeb.config.auto_dark_mode %>
+    @media (prefers-color-scheme: dark) {
+        body {
+            background-color: black;
+        }
+        .left, .right {
+            filter: invert(1) hue-rotate(180deg);
+        }
+    }
+  <% end %>
 
   body {
     margin: 0

--- a/lib/letter_opener_web.rb
+++ b/lib/letter_opener_web.rb
@@ -7,11 +7,13 @@ require 'rexml/document'
 module LetterOpenerWeb
   class Config
     attr_accessor :letters_location
+    attr_accessor :auto_dark_mode
   end
 
   def self.config
     @config ||= Config.new.tap do |conf|
       conf.letters_location = Rails.root.join('tmp', 'letter_opener')
+      conf.auto_dark_mode = false
     end
   end
 

--- a/lib/letter_opener_web.rb
+++ b/lib/letter_opener_web.rb
@@ -6,8 +6,7 @@ require 'rexml/document'
 
 module LetterOpenerWeb
   class Config
-    attr_accessor :letters_location
-    attr_accessor :auto_dark_mode
+    attr_accessor :letters_location, :auto_dark_mode
   end
 
   def self.config


### PR DESCRIPTION
## Problem
LetterOpenerWeb currently applies a forced filter: invert() dark-mode strategy at the iframe container level. This conflicts with modern email templates that already implement `prefers-color-scheme` styling, resulting in double inversion and broken colors.

## Proposal
Make dark-mode inversion opt-in, via a `LetterOpenWeb.config.auto_dark_mode` config option (default `false`). This aligns LetterOpenerWeb with current email client behavior and restores accurate visual testing.

## Impact
- Improves email QA accuracy
- Prevents color distortion
- Maintains backward compatibility if opt-in

## Current Behavior (Light Mode)
<img width="1725" height="1003" alt="Screenshot 2025-12-17 at 9 51 47 PM-annotated" src="https://github.com/user-attachments/assets/ee8bc624-f641-43ce-9584-0b549950cf30" />

## Current Behavior (Dark Mode)
Notice despite email declaring its own `prefers-color-scheme` styling, it gets inverted.

<img width="1720" height="996" alt="Screenshot 2025-12-17 at 9 51 59 PM-annotated" src="https://github.com/user-attachments/assets/a2a8a0e0-aad1-4af5-92f1-f199f67b0ded" />


## Proposed Behavior (Dark Mode)
Email dark mode styling is respected as-is, when `LetterOpenWeb.config.auto_dark_mode = false`

<img width="1728" height="996" alt="Screenshot 2025-12-17 at 9 55 54 PM-annotated" src="https://github.com/user-attachments/assets/9e48d7d2-4a0b-479d-ba19-5809f738c7b4" />
