### PR TITLE
Add Rails8.1 and Ruby4.0 to the CI matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,7 @@ jobs:
           - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
           - truffleruby-head
         rails-version:
           - "6_1"
@@ -56,7 +57,11 @@ jobs:
         exclude:
           - ruby-version: "3.4"
             rails-version: "6_1"
+          - ruby-version: "4.0"
+            rails-version: "6_1"
           - ruby-version: "3.4"
+            rails-version: "7_0"
+          - ruby-version: "4.0"
             rails-version: "7_0"
           - ruby-version: "3.1"
             rails-version: "8_0"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Ruby 3.4
+      - name: Set up latest Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4"
+          ruby-version: ruby
           bundler-cache: true
 
       - name: Lint with Rubocop
@@ -27,10 +27,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Ruby 3.4
+      - name: Set up latest Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4"
+          ruby-version: ruby
           bundler-cache: true
 
       - name: Build gem

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Ruby 3.4
         uses: ruby/setup-ruby@v1
@@ -25,7 +25,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Ruby 3.4
         uses: ruby/setup-ruby@v1
@@ -71,7 +71,7 @@ jobs:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails-version }}.gemfile
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,7 @@ jobs:
           - "7_1"
           - "7_2"
           - "8_0"
+          - "8_1"
         exclude:
           - ruby-version: "3.4"
             rails-version: "6_1"
@@ -59,6 +60,8 @@ jobs:
             rails-version: "7_0"
           - ruby-version: "3.1"
             rails-version: "8_0"
+          - ruby-version: "3.1"
+            rails-version: "8_1"
     env:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails-version }}.gemfile
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
           - "3.3"
           - "3.4"
           - "4.0"
-          - truffleruby-head
+          - truffleruby-33.0.1
         rails-version:
           - "6_1"
           - "7_0"

--- a/gemfiles/rails_8_1.gemfile
+++ b/gemfiles/rails_8_1.gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source 'http://rubygems.org'
+
+gemspec path: '../'
+
+gem 'rails', '~> 8.1.0'
+gem 'rspec-rails', '~> 7.1.0'


### PR DESCRIPTION
- Add Rails8.1
- Add Ruby4.0
- Update actions/checkout to the latest version
- Set the Ruby version used by Rubocop and the build to always use the latest stable release