### PR TITLE
feat: Add configurable HTTP Basic Authentication for the web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,38 @@ end
 When enabled, LetterOpenerWeb applies a CSS-based inversion strategy to
 approximate dark mode for templates that do not define their own styles,
 similar to high-contrast or browser-level color inversion.
+### HTTP Basic Authentication
+
+When using the gem in staging or pre-production, you can protect the web interface with
+HTTP Basic Auth. By default, authentication is disabled for ease of setup.
+
+```ruby
+# config/initializers/letter_opener_web.rb
+LetterOpenerWeb.configure do |config|
+  # By default, authentication is disabled for ease of setup
+  config.authentication_enabled = false
+
+  # Set the username for HTTP Basic Authentication (only used if authentication is enabled)
+  config.username = 'admin'
+
+  # Set the password for HTTP Basic Authentication (only used if authentication is enabled)
+  config.password = 'password'
+end
+```
+
+To enable authentication, set `authentication_enabled = true` and ensure both `username` and
+`password` are set. Every request to the Letter Opener Web UI will then require HTTP Basic
+Authentication.
+
+For staging, prefer environment variables so credentials are not committed:
+
+```ruby
+LetterOpenerWeb.configure do |config|
+  config.authentication_enabled = true
+  config.username = ENV['LETTER_OPENER_WEB_USERNAME']
+  config.password = ENV['LETTER_OPENER_WEB_PASSWORD']
+end
+```
 
 ## Usage on pre-production environments
 

--- a/app/controllers/letter_opener_web/application_controller.rb
+++ b/app/controllers/letter_opener_web/application_controller.rb
@@ -2,6 +2,22 @@
 
 module LetterOpenerWeb
   class ApplicationController < ActionController::Base
+    before_action :enforce_basic_auth, if: :basic_auth_configured?
+
     protect_from_forgery with: :exception, unless: -> { Rails.configuration.try(:api_only) }
+
+    private
+
+    def basic_auth_configured?
+      LetterOpenerWeb.config.basic_auth_enabled?
+    end
+
+    def enforce_basic_auth
+      authenticate_or_request_with_http_basic('Letter Opener Web') do |username, password|
+        config = LetterOpenerWeb.config
+        ActiveSupport::SecurityUtils.secure_compare(username, config.username) &
+          ActiveSupport::SecurityUtils.secure_compare(password, config.password)
+      end
+    end
   end
 end

--- a/app/controllers/letter_opener_web/application_controller.rb
+++ b/app/controllers/letter_opener_web/application_controller.rb
@@ -2,7 +2,7 @@
 
 module LetterOpenerWeb
   class ApplicationController < ActionController::Base
-    before_action :enforce_basic_auth, if: -> { LetterOpenerWeb.config.enabled? }
+    before_action :enforce_basic_auth, if: -> { LetterOpenerWeb.config.basic_auth_enabled? }
 
     protect_from_forgery with: :exception, unless: -> { Rails.configuration.try(:api_only) }
 

--- a/app/controllers/letter_opener_web/application_controller.rb
+++ b/app/controllers/letter_opener_web/application_controller.rb
@@ -2,21 +2,17 @@
 
 module LetterOpenerWeb
   class ApplicationController < ActionController::Base
-    before_action :enforce_basic_auth, if: :basic_auth_configured?
+    before_action :enforce_basic_auth, if: -> { LetterOpenerWeb.config.enabled? }
 
     protect_from_forgery with: :exception, unless: -> { Rails.configuration.try(:api_only) }
 
     private
 
-    def basic_auth_configured?
-      LetterOpenerWeb.config.basic_auth_enabled?
-    end
-
     def enforce_basic_auth
       authenticate_or_request_with_http_basic('Letter Opener Web') do |username, password|
         config = LetterOpenerWeb.config
-        ActiveSupport::SecurityUtils.secure_compare(username, config.username) &
-          ActiveSupport::SecurityUtils.secure_compare(password, config.password)
+        ActiveSupport::SecurityUtils.secure_compare(username, config.username.to_s) &
+          ActiveSupport::SecurityUtils.secure_compare(password, config.password.to_s)
       end
     end
   end

--- a/lib/letter_opener_web.rb
+++ b/lib/letter_opener_web.rb
@@ -6,15 +6,14 @@ require 'rexml/document'
 
 module LetterOpenerWeb
   class Config
-    attr_accessor :letters_location, :auto_dark_mode
-    attr_accessor :authentication_enabled
-    attr_accessor :username, :password
+    attr_accessor :letters_location, :auto_dark_mode, :authentication_enabled, :username, :password
 
     def basic_auth_enabled?
       authentication_enabled && username.present? && password.present?
     end
+    alias enabled? basic_auth_enabled?
 
-    def validate!
+    def warn_if_basic_auth_misconfigured
       return unless authentication_enabled && (username.blank? || password.blank?)
 
       Rails.logger.warn('[LetterOpenerWeb] authentication_enabled is true but username or password is blank. ' \
@@ -32,7 +31,7 @@ module LetterOpenerWeb
 
   def self.configure
     yield config if block_given?
-    config.validate!
+    config.warn_if_basic_auth_misconfigured
   end
 
   def self.reset!

--- a/lib/letter_opener_web.rb
+++ b/lib/letter_opener_web.rb
@@ -11,7 +11,6 @@ module LetterOpenerWeb
     def basic_auth_enabled?
       authentication_enabled && username.present? && password.present?
     end
-    alias enabled? basic_auth_enabled?
 
     def warn_if_basic_auth_misconfigured
       return unless authentication_enabled && (username.blank? || password.blank?)

--- a/lib/letter_opener_web.rb
+++ b/lib/letter_opener_web.rb
@@ -7,17 +7,32 @@ require 'rexml/document'
 module LetterOpenerWeb
   class Config
     attr_accessor :letters_location, :auto_dark_mode
+    attr_accessor :authentication_enabled
+    attr_accessor :username, :password
+
+    def basic_auth_enabled?
+      authentication_enabled && username.present? && password.present?
+    end
+
+    def validate!
+      return unless authentication_enabled && (username.blank? || password.blank?)
+
+      Rails.logger.warn('[LetterOpenerWeb] authentication_enabled is true but username or password is blank. ' \
+                        'Basic auth will not be enforced.')
+    end
   end
 
   def self.config
     @config ||= Config.new.tap do |conf|
       conf.letters_location = Rails.root.join('tmp', 'letter_opener')
       conf.auto_dark_mode = false
+      conf.authentication_enabled = false
     end
   end
 
   def self.configure
     yield config if block_given?
+    config.validate!
   end
 
   def self.reset!

--- a/spec/controllers/letter_opener_web/letters_controller_spec.rb
+++ b/spec/controllers/letter_opener_web/letters_controller_spec.rb
@@ -25,21 +25,24 @@ RSpec.describe LetterOpenerWeb::LettersController do
 
       it 'returns 200 with correct credentials' do
         allow(LetterOpenerWeb::Letter).to receive(:search)
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials('admin', 'secret')
+        request.env['HTTP_AUTHORIZATION'] =
+          ActionController::HttpAuthentication::Basic.encode_credentials('admin', 'secret')
         get :index
         expect(response.status).to eq(200)
       end
 
       it 'returns 401 with wrong password' do
         allow(LetterOpenerWeb::Letter).to receive(:search)
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials('admin', 'wrong')
+        request.env['HTTP_AUTHORIZATION'] =
+          ActionController::HttpAuthentication::Basic.encode_credentials('admin', 'wrong')
         get :index
         expect(response.status).to eq(401)
       end
 
       it 'returns 401 with wrong username' do
         allow(LetterOpenerWeb::Letter).to receive(:search)
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials('wrong', 'secret')
+        request.env['HTTP_AUTHORIZATION'] =
+          ActionController::HttpAuthentication::Basic.encode_credentials('wrong', 'secret')
         get :index
         expect(response.status).to eq(401)
       end

--- a/spec/controllers/letter_opener_web/letters_controller_spec.rb
+++ b/spec/controllers/letter_opener_web/letters_controller_spec.rb
@@ -7,6 +7,69 @@ RSpec.describe LetterOpenerWeb::LettersController do
 
   after(:each) { LetterOpenerWeb.reset! }
 
+  describe 'Basic authentication' do
+    context 'when authentication is enabled with username and password' do
+      before do
+        LetterOpenerWeb.configure do |config|
+          config.authentication_enabled = true
+          config.username = 'admin'
+          config.password = 'secret'
+        end
+      end
+
+      it 'returns 401 Unauthorized without credentials' do
+        allow(LetterOpenerWeb::Letter).to receive(:search)
+        get :index
+        expect(response.status).to eq(401)
+      end
+
+      it 'returns 200 with correct credentials' do
+        allow(LetterOpenerWeb::Letter).to receive(:search)
+        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials('admin', 'secret')
+        get :index
+        expect(response.status).to eq(200)
+      end
+
+      it 'returns 401 with wrong password' do
+        allow(LetterOpenerWeb::Letter).to receive(:search)
+        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials('admin', 'wrong')
+        get :index
+        expect(response.status).to eq(401)
+      end
+
+      it 'returns 401 with wrong username' do
+        allow(LetterOpenerWeb::Letter).to receive(:search)
+        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials('wrong', 'secret')
+        get :index
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context 'when authentication_enabled is false' do
+      before do
+        LetterOpenerWeb.configure do |config|
+          config.authentication_enabled = false
+          config.username = 'admin'
+          config.password = 'secret'
+        end
+      end
+
+      it 'allows access without credentials even when username and password are set' do
+        allow(LetterOpenerWeb::Letter).to receive(:search)
+        get :index
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context 'when username and password are not configured' do
+      it 'allows access without credentials' do
+        allow(LetterOpenerWeb::Letter).to receive(:search)
+        get :index
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+
   describe 'GET index' do
     before do
       allow(LetterOpenerWeb::Letter).to receive(:search)

--- a/spec/letter_opener_web_spec.rb
+++ b/spec/letter_opener_web_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe LetterOpenerWeb do
     it 'sets defaults' do
       expected = Rails.root.join('tmp', 'letter_opener')
       expect(subject.config.letters_location).to eq(expected)
+      expect(subject.config.authentication_enabled).to eq(false)
     end
   end
 
@@ -39,6 +40,51 @@ RSpec.describe LetterOpenerWeb do
 
       expected = Rails.root.join('tmp', 'letter_opener')
       expect(subject.config.letters_location).to eq(expected)
+    end
+  end
+
+  describe 'basic auth config' do
+    it 'basic_auth_enabled? is false when authentication_enabled is false' do
+      subject.configure do |config|
+        config.authentication_enabled = false
+        config.username = 'admin'
+        config.password = 'secret'
+      end
+      expect(subject.config.basic_auth_enabled?).to eq(false)
+    end
+
+    it 'basic_auth_enabled? is false when username or password are blank' do
+      subject.configure do |config|
+        config.authentication_enabled = true
+        config.username = ''
+        config.password = 'secret'
+      end
+      expect(subject.config.basic_auth_enabled?).to eq(false)
+
+      subject.configure do |config|
+        config.authentication_enabled = true
+        config.username = 'admin'
+        config.password = ''
+      end
+      expect(subject.config.basic_auth_enabled?).to eq(false)
+    end
+
+    it 'basic_auth_enabled? is true when authentication_enabled and both username and password are set' do
+      subject.configure do |config|
+        config.authentication_enabled = true
+        config.username = 'admin'
+        config.password = 'secret'
+      end
+      expect(subject.config.basic_auth_enabled?).to eq(true)
+    end
+
+    it 'logs a warning when authentication_enabled is true but credentials are missing' do
+      expect(Rails.logger).to receive(:warn).with(/authentication_enabled is true but username or password is blank/)
+      subject.configure do |config|
+        config.authentication_enabled = true
+        config.username = 'admin'
+        config.password = ''
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
Adds opt-in HTTP Basic Authentication to protect the Letter Opener Web interface, primarily useful for staging and pre-production environments where the UI is accessible but should not be publicly open.

Users can enable it via the existing LetterOpenerWeb.configure block in a Rails initializer:
` LetterOpenerWeb.configure do |config|
   config.authentication_enabled = true
   config.username = ENV['LETTER_OPENER_WEB_USERNAME']
   config.password = ENV['LETTER_OPENER_WEB_PASSWORD']
 end
`

 ## Details

 - Opt-in by default -- authentication_enabled defaults to false, so existing users are unaffected.
 - No new dependencies -- uses Rails' built-in authenticate_or_request_with_http_basic and ActiveSupport::SecurityUtils.secure_compare for constant-time credential comparison.
 - Misconfiguration warning -- if authentication_enabled is true but username or password is blank, a warning is logged at boot time via Rails.logger.warn so the issue is caught early.
 - Config options: authentication_enabled (boolean), username (string), password (string) -- all added to LetterOpenerWeb::Config, consistent with the existing letters_location pattern.

 ## Test plan

 - [x] Auth enabled + correct credentials returns 200
 - [x] Auth enabled + no credentials returns 401
 - [x] Auth enabled + wrong username returns 401
 - [x] Auth enabled + wrong password returns 401
 - [x] Auth disabled (default) allows access without credentials
 - [x] Auth disabled with username/password set still allows open access
 - [x] basic_auth_enabled? returns correct value for all config combinations
 - [x] Warning is logged when authentication_enabled = true but credentials are blank